### PR TITLE
Commands to customize colors and DuckDuckGo search

### DIFF
--- a/src/js/commands.js
+++ b/src/js/commands.js
@@ -1,28 +1,60 @@
 // Search something on google, if no arguments are provided => www.google.com
-g = google;
+g = google
 function google(args) {
-    if (args != undefined) {
-        search = args.replace(" ", "+")
-        window.open("https://www.google.com/search?q=" + search);
-    } else {
-        window.open("https://www.google.com");
-    }
+	if (args != undefined) {
+		search = args.replace(" ", "+")
+		window.location.href = "https://www.google.com/search?q=" + search
+	} else {
+		window.location.href = "https://www.google.com"
+	}
+}
+
+// Search something on duckduckgo, if no arguments are provided => duckduckgo.com
+d = duckduckgo
+function duckduckgo(args) {
+	if (args != undefined) {
+		search = args.replace(" ", "+")
+		window.location.href = "https://duckduckgo.com/?q=" + search
+	} else {
+		window.location.href = "https://duckduckgo.com/"
+	}
 }
 
 // Display time
-time = clock;
+time = clock
 function clock(args) {
-    var today = new Date();
-    block_log(today.getHours() + ":" + today.getMinutes() + ":" + today.getSeconds());
+	var today = new Date()
+	block_log(
+		today.getHours() + ":" + today.getMinutes() + ":" + today.getSeconds()
+	)
 }
 
 // Clear the terminal
-cls = clear;
+cls = clear
 function clear(args) {
-    document.getElementById('wrapper').innerHTML = "";
+	document.getElementById("wrapper").innerHTML = ""
 }
 
+textcolor = setColor
+function setColor(args) {
+	if (args != undefined) {
+		document.documentElement.style.setProperty("--text-color", args)
+		document.cookie = "textcolor=" + args
+	}
+}
 
+bgcolor = setBgColor
+function setBgColor(args) {
+	if (args != undefined) {
+		document.documentElement.style.setProperty("--main-bg-color", args)
+		document.cookie = "bgcolor=" + args
+	}
+}
 
-
-
+promptcolor = setPromptColor
+function setPromptColor(args) {
+	if (args != undefined) {
+		document.documentElement.style.setProperty("--prompt-bg-color", args)
+		document.cookie = "promptcolor=" + args
+	}
+}

--- a/src/js/terminal.js
+++ b/src/js/terminal.js
@@ -1,47 +1,73 @@
 // Terminal config
 config = {
-    shellPrompt: "$ "
+	shellPrompt: "$ ",
 }
 
-document.getElementById("input_title").innerText = config.shellPrompt;
-document.getElementById('input_source').addEventListener('keyup', submit_command);
-document.getElementById('input_source').addEventListener('keyup', getLastCommand);
+document.getElementById("input_title").innerText = config.shellPrompt
+document
+	.getElementById("input_source")
+	.addEventListener("keyup", submit_command)
+document
+	.getElementById("input_source")
+	.addEventListener("keyup", getLastCommand)
 
-var current_block;
+var current_block
 
 function new_block() {
-    current_block = document.createElement("div");
-    current_block.classList.add("log");
-    document.getElementById('wrapper').appendChild(current_block);
+	current_block = document.createElement("div")
+	current_block.classList.add("log")
+	document.getElementById("wrapper").appendChild(current_block)
 }
 
 function block_log(message) {
-    current_block.innerHTML = "<p>" + message + "</p>";
-    new_block();
+	current_block.innerHTML = "<p>" + message + "</p>"
+	new_block()
 }
 
 function submit_command() {
-    if (!(event.keyCode === 13)) return;
-    var input = document.getElementById("input_source").value;
-    document.getElementById("input_source").value = "";
+	if (!(event.keyCode === 13)) return
+	var input = document.getElementById("input_source").value
+	document.getElementById("input_source").value = ""
 
-    new_block();
+	new_block()
 
-    command = input.split(" ")[0];
-    args = input.replace(command, "")
+	command = input.split(" ")[0]
+	args = input.replace(command, "")
 
-    if (typeof window[command] === "function") {
-        block_log(config.shellPrompt + command + " " + args);
-        window[command](args);
-        lastCommand = command + args;
-    } else if (command != "") {
-        block_log("command not found : " + command);
-    }
+	if (typeof window[command] === "function") {
+		block_log(config.shellPrompt + command + " " + args)
+		window[command](args)
+		lastCommand = command + args
+	} else if (command != "") {
+		block_log("command not found : " + command)
+	}
 }
 
 function getLastCommand() {
-    if (!(event.keyCode === 38)) return;
-    if (lastCommand) {
-        document.getElementById("input_source").value = lastCommand;
-    }
+	if (!(event.keyCode === 38)) return
+	if (lastCommand) {
+		document.getElementById("input_source").value = lastCommand
+	}
 }
+
+cookies = document.cookie.split(";")
+cookies.forEach((cookie) => {
+	if (cookie.includes("promptcolor")) {
+		document.documentElement.style.setProperty(
+			"--prompt-bg-color",
+			cookie.slice(cookie.indexOf("=") + 1)
+		)
+	}
+	if (cookie.includes("textcolor")) {
+		document.documentElement.style.setProperty(
+			"--text-color",
+			cookie.slice(cookie.indexOf("=") + 1)
+		)
+	}
+	if (cookie.includes("bgcolor")) {
+		document.documentElement.style.setProperty(
+			"--main-bg-color",
+			cookie.slice(cookie.indexOf("=") + 1)
+		)
+	}
+})


### PR DESCRIPTION
I added the command `duckduckgo` (or only `d`), it works equals `google` but with DuckDuckGo.

I also added these commands: 
1. `textcolor` - it receives an arg with the color that you want to set text color
2. `bgcolor` - it receives an arg with the color that you want to set the page background color
3. `promptcolor` - it receives an arg with the color that you want to set prompt color
All these commands save the changes with cookies.